### PR TITLE
Add full RegEx instructions to grep allowing complex exclusions

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ THRESHOLD_WARN=${WERCKER_GOLINT_THRESHOLD_WARN-5}
 THRESHOLD_FAIL=${WERCKER_GOLINT_THRESHOLD_FAIL-10}
 
 if [ -n "$WERCKER_GOLINT_EXCLUDE" ]; then
-  LINTLINES=$("$WERCKER_STEP_ROOT"/golint ./... | grep -ve "$WERCKER_GOLINT_EXCLUDE" | tee lint_results.txt | wc -l | tr -d " ")
+  LINTLINES=$("$WERCKER_STEP_ROOT"/golint ./... | grep -vE "$WERCKER_GOLINT_EXCLUDE" | tee lint_results.txt | wc -l | tr -d " ")
 else
   LINTLINES=$("$WERCKER_STEP_ROOT"/golint ./... | tee lint_results.txt | wc -l | tr -d " ")
 fi


### PR DESCRIPTION
This allows users to include more complex RegEx in their exclusions pattern. The previous `-e` options allowed for one and only one expression (e.g. `vendor/`) but some projects might want to exclude specific files or folders (e.g. protobuf generated files).

The `-E` options just add RegEx instructions to the current used option. It's backward compatible.